### PR TITLE
RabbitMQ command update to enable management plugin

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -84,6 +84,9 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
+    command: >
+      sh -c "rabbitmq-plugins enable rabbitmq_management &&
+             rabbitmq-server"
     networks:
       - backend
 


### PR DESCRIPTION
Added a command for the rabbitMQ service enabling the management plugin.