### PR TITLE
CI runner update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   detect-changes:
     name: Detect Changed Services
-    runs-on: self-hosted
+    runs-on: mtogo-test
     outputs:
       changed-services: ${{ steps.filter.outputs.changes }}
     steps:
@@ -48,7 +48,7 @@ jobs:
     name: Test & Build per Service
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.changed-services != '[]' }}
-    runs-on: self-hosted
+    runs-on: mtogo-test
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Updated CI workflow to only run on test runner, because Maven is not installed (and not needed) on the prod runner.