### PR TITLE
Health checks update

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
           function check_health {
             local URL=$1
             for i in $(seq 1 $MAX_RETRIES); do
-              HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+              HTTP_CODE=$(curl -sfL -o /dev/null -w "%{http_code}" "$URL" || echo "000")
               if [ "$HTTP_CODE" -eq 200 ]; then
                 echo "$URL healthy."
                 return 0


### PR DESCRIPTION
When running health checks the curl command is now following redirects, so checks doesn't fail because caddy redirects from http to https.