### PR TITLE
Updated javalin config

### DIFF
--- a/services/courier-service/src/main/java/mtogo/courier/server/JavalinBuilder.java
+++ b/services/courier-service/src/main/java/mtogo/courier/server/JavalinBuilder.java
@@ -1,6 +1,7 @@
 package mtogo.courier.server;
 
 import io.javalin.Javalin;
+import io.javalin.http.staticfiles.Location;
 import mtogo.courier.exceptions.APIException;
 import mtogo.courier.exceptions.ExceptionHandler;
 
@@ -14,6 +15,7 @@ public class JavalinBuilder {
                         staticFiles.hostedPath = "/";
                         staticFiles.directory = "/app/public";
                         staticFiles.precompress = true;
+                        staticFiles.location = Location.EXTERNAL;
                     });
                     config.router.apiBuilder(() -> {
                         path("/api", () -> {


### PR DESCRIPTION
Javalin config updated to explicitly tell javalin that static files are to be found externally instead of within its own ressources.